### PR TITLE
fix(errors) subprocess.SubprocessError doesn't exist

### DIFF
--- a/jira/package_meta.py
+++ b/jira/package_meta.py
@@ -60,7 +60,7 @@ def run_but_ignore_errors(*args, **kwargs):
         try:
             return subprocess.check_output(*args, shell=True, stderr=devnull,
                                            **kwargs)
-        except (subprocess.SubprocessError,
+        except (subprocess.CalledProcessError,
                 FileNotFoundError, OSError):
             return None
         except Exception:


### PR DESCRIPTION
Change to subproocess.CalledProcessError (https://docs.python.org/2/library/subprocess.html#subprocess.CalledProcessError)
